### PR TITLE
Add backend env example and ignore

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://repas:repas@localhost:5432/repas

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.env


### PR DESCRIPTION
## Summary
- add `.env.example` with default DB configuration
- ignore `.env` in backend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68424aa764608323b6d2530363b06827