### PR TITLE
Add lunch and dinner support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
     - optional `image_url` field
   - `recipe_ingredients`
   - `menus`
-  - `menu_recipes`
+  - `menu_recipes` (stores one row per day and meal: `dejeuner` or `diner`)
 - Schema managed using `node-pg-migrate`
 - Environment file `.env` used for PostgreSQL connection
 

--- a/backend/migrations/1750000000000_add-moment-to-menu-recipes.js
+++ b/backend/migrations/1750000000000_add-moment-to-menu-recipes.js
@@ -1,0 +1,24 @@
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.addColumn('menu_recipes', {
+    moment: {
+      type: 'text',
+      notNull: true,
+      default: 'dejeuner',
+      check: "moment IN ('dejeuner','diner')",
+    },
+  });
+  pgm.dropConstraint('menu_recipes', 'unique_menu_jour');
+  pgm.addConstraint('menu_recipes', 'unique_menu_jour_moment', {
+    unique: ['menu_id', 'jour', 'moment'],
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropConstraint('menu_recipes', 'unique_menu_jour_moment');
+  pgm.addConstraint('menu_recipes', 'unique_menu_jour', {
+    unique: ['menu_id', 'jour'],
+  });
+  pgm.dropColumn('menu_recipes', 'moment');
+};

--- a/frontend/src/pages/MenuPage.vue
+++ b/frontend/src/pages/MenuPage.vue
@@ -19,7 +19,8 @@ const days = [
         class="bg-white rounded shadow p-4"
       >
         <h2 class="font-medium mb-2">{{ day }}</h2>
-        <p class="text-sm text-gray-600">Recipe placeholder</p>
+        <p class="text-sm text-gray-600">Lunch: Recipe placeholder</p>
+        <p class="text-sm text-gray-600">Dinner: Recipe placeholder</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- store meal in menu recipes with new migration
- show placeholders for lunch and dinner on menu page
- clarify schema changes in README

## Testing
- `npm run lint` in `backend`
- `npm test` in `backend`
- `npm run lint` in `frontend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68429298ec008323ac78048fa1b076fc