### PR TITLE
Add recipe creation page

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,31 @@
+export const API_BASE_URL = 'http://localhost:3000'
+
+export interface RecipePayload {
+  nom: string
+  ingredient_principal_id: string
+  instructions?: string
+  ingredient_secondaire_id?: string
+  image_url?: string
+}
+
+export async function fetchRecipes() {
+  const res = await globalThis.fetch(`${API_BASE_URL}/recipes`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch recipes')
+  }
+  return res.json()
+}
+
+export async function createRecipe(payload: RecipePayload) {
+  const res = await globalThis.fetch(`${API_BASE_URL}/recipes`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  })
+  if (!res.ok) {
+    throw new Error('Failed to create recipe')
+  }
+  return res.json()
+}

--- a/frontend/src/pages/AddRecipePage.vue
+++ b/frontend/src/pages/AddRecipePage.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { createRecipe } from '../api'
+
+const nom = ref('')
+const instructions = ref('')
+const ingredientPrincipalId = ref('')
+const router = useRouter()
+
+const submit = async () => {
+  try {
+    await createRecipe({
+      nom: nom.value,
+      ingredient_principal_id: ingredientPrincipalId.value,
+      instructions: instructions.value || undefined
+    })
+    router.push('/recipes')
+  } catch {
+    // ignore error for now
+  }
+}
+</script>
+<template>
+  <div class="max-w-md mx-auto">
+    <h1 class="text-2xl font-bold mb-4">Ajouter une recette</h1>
+    <form @submit.prevent="submit" class="space-y-4">
+      <div>
+        <label class="block mb-1">Nom</label>
+        <input v-model="nom" class="border rounded w-full p-2" required />
+      </div>
+      <div>
+        <label class="block mb-1">Instructions</label>
+        <textarea v-model="instructions" class="border rounded w-full p-2" />
+      </div>
+      <div>
+        <label class="block mb-1">Ingredient principal ID</label>
+        <input v-model="ingredientPrincipalId" class="border rounded w-full p-2" required />
+      </div>
+      <button type="submit" class="px-3 py-1 bg-blue-600 text-white rounded">Enregistrer</button>
+    </form>
+  </div>
+</template>

--- a/frontend/src/pages/RecipesPage.vue
+++ b/frontend/src/pages/RecipesPage.vue
@@ -1,21 +1,36 @@
 <script setup lang="ts">
-const recipes = Array.from({ length: 4 }).map((_, i) => ({
-  id: i + 1,
-  title: `Recipe ${i + 1}`,
-  description: 'A tasty meal awaits you.'
-}))
+import { onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import { fetchRecipes } from '../api'
+
+const recipes = ref([])
+
+onMounted(async () => {
+  try {
+    recipes.value = await fetchRecipes()
+  } catch {
+    // ignore error for now
+  }
+})
 </script>
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-4">Recipes</h1>
+    <div class="flex items-center justify-between mb-4">
+      <h1 class="text-2xl font-bold">Recipes</h1>
+      <RouterLink
+        to="/recipes/add"
+        class="px-3 py-1 bg-blue-600 text-white rounded"
+        >Ajouter une recette</RouterLink
+      >
+    </div>
     <div class="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
       <div
         v-for="recipe in recipes"
         :key="recipe.id"
         class="bg-white rounded shadow p-4"
       >
-        <h2 class="font-medium text-lg mb-1">{{ recipe.title }}</h2>
-        <p class="text-sm text-gray-600">{{ recipe.description }}</p>
+        <h2 class="font-medium text-lg mb-1">{{ recipe.nom }}</h2>
+        <p class="text-sm text-gray-600">{{ recipe.instructions }}</p>
       </div>
     </div>
   </div>

--- a/frontend/src/router.test.ts
+++ b/frontend/src/router.test.ts
@@ -5,6 +5,7 @@ describe('router', () => {
   it('should have recipe and menu routes', () => {
     const paths = routes.map(r => r.path)
     expect(paths).toContain('/recipes')
+    expect(paths).toContain('/recipes/add')
     expect(paths).toContain('/menu')
   })
 })

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -1,10 +1,12 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import RecipesPage from './pages/RecipesPage.vue'
+import AddRecipePage from './pages/AddRecipePage.vue'
 import MenuPage from './pages/MenuPage.vue'
 
 export const routes = [
   { path: '/', redirect: '/recipes' },
   { path: '/recipes', component: RecipesPage },
+  { path: '/recipes/add', component: AddRecipePage },
   { path: '/menu', component: MenuPage }
 ]
 


### PR DESCRIPTION
## Summary
- allow navigating to add recipe page from recipe list
- implement add recipe form and API utilities
- register new route for recipe creation
- update router tests

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842a20791cc832396f84b1c4f9c0262