### PR TITLE
Implement secondary ingredient selection

### DIFF
--- a/frontend/src/pages/AddRecipePage.vue
+++ b/frontend/src/pages/AddRecipePage.vue
@@ -6,18 +6,20 @@ import IngredientInput from '../components/IngredientInput.vue'
 
 const nom = ref('')
 const instructions = ref('')
-const ingredientPrincipalId = ref('')
 const imageUrl = ref('')
 const ingredients = ref([
   { nom: '', quantite: '', unite: '' }
 ])
+const secondaryIdx = ref<number | null>(null)
 const router = useRouter()
 
 const submit = async () => {
   try {
     await createRecipe({
       nom: nom.value,
-      ingredient_principal_id: ingredientPrincipalId.value,
+      ingredient_principal_id: ingredients.value[0].id || '',
+      ingredient_secondaire_id:
+        secondaryIdx.value !== null ? ingredients.value[secondaryIdx.value].id : undefined,
       instructions: instructions.value || undefined,
       image_url: imageUrl.value || undefined,
       ingredients: ingredients.value
@@ -30,6 +32,21 @@ const submit = async () => {
 
 const addIngredient = () => {
   ingredients.value.push({ nom: '', quantite: '', unite: '' })
+}
+
+const removeIngredient = (idx: number) => {
+  ingredients.value.splice(idx, 1)
+  if (secondaryIdx.value !== null) {
+    if (secondaryIdx.value === idx) {
+      secondaryIdx.value = null
+    } else if (secondaryIdx.value > idx) {
+      secondaryIdx.value -= 1
+    }
+  }
+}
+
+const toggleSecondary = (idx: number) => {
+  secondaryIdx.value = secondaryIdx.value === idx ? null : idx
 }
 </script>
 <template>
@@ -50,16 +67,18 @@ const addIngredient = () => {
       </div>
       <div>
         <label class="block mb-1">Ingrédients</label>
-        <IngredientInput
-          v-for="(ing, idx) in ingredients"
-          :key="idx"
-          v-model="ingredients[idx]"
-        />
+        <div v-for="(ing, idx) in ingredients" :key="idx" class="mb-2">
+          <IngredientInput v-model="ingredients[idx]" />
+          <p v-if="idx === 0" class="text-sm text-gray-500">Ingrédient principal de la recette</p>
+          <div v-else class="flex items-center space-x-2">
+            <label class="flex items-center space-x-1">
+              <input type="checkbox" :checked="secondaryIdx === idx" @change="toggleSecondary(idx)" />
+              <span>Ingrédient secondaire</span>
+            </label>
+            <button type="button" @click="removeIngredient(idx)" class="text-red-600 text-sm">Supprimer l'ingrédient</button>
+          </div>
+        </div>
         <button type="button" @click="addIngredient" class="px-2 py-1 bg-gray-200 rounded">Ajouter un ingrédient</button>
-      </div>
-      <div>
-        <label class="block mb-1">Ingredient principal ID</label>
-        <input v-model="ingredientPrincipalId" class="border rounded w-full p-2" required />
       </div>
       <button type="submit" class="px-3 py-1 bg-blue-600 text-white rounded">Enregistrer</button>
     </form>


### PR DESCRIPTION
## Summary
- add logic to mark an ingredient as secondary and remove from the list
- automatically use the first ingredient as the main ingredient
- update recipe creation page UI to support secondary ingredient selection

## Testing
- `npm run lint` *(fails: npm not found?)*
- `npm test` *(fails: npm not found?)*

------
https://chatgpt.com/codex/tasks/task_e_6842a9087f5c8323a780ebea8bdb8aa4