### PR TITLE
Fix ingredient checkbox & enable CORS

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "repas-backend",
       "version": "1.0.0",
       "dependencies": {
+        "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "pg": "^8.11.1"
@@ -2486,6 +2487,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -4308,6 +4322,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
-    "pg": "^8.11.1"
+    "pg": "^8.11.1",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import dotenv from 'dotenv';
+import cors from 'cors';
 import recipeRoutes from './routes/recipes';
 import ingredientRoutes from './routes/ingredients';
 
@@ -9,6 +10,7 @@ const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(express.json());
+app.use(cors());
 app.use('/recipes', recipeRoutes);
 app.use('/ingredients', ingredientRoutes);
 

--- a/frontend/src/pages/AddRecipePage.vue
+++ b/frontend/src/pages/AddRecipePage.vue
@@ -70,7 +70,7 @@ const toggleSecondary = (idx: number) => {
         <div v-for="(ing, idx) in ingredients" :key="idx" class="mb-2">
           <IngredientInput v-model="ingredients[idx]" />
           <p v-if="idx === 0" class="text-sm text-gray-500">Ingrédient principal de la recette</p>
-          <div v-else class="flex items-center space-x-2">
+          <div v-if="idx > 0" class="flex items-center space-x-2">
             <label class="flex items-center space-x-1">
               <input type="checkbox" :checked="secondaryIdx === idx" @change="toggleSecondary(idx)" />
               <span>Ingrédient secondaire</span>


### PR DESCRIPTION
## Summary
- display "ingrédient secondaire" checkbox for all ingredients after the first
- allow cross-origin requests to the backend

## Testing
- `npm run lint` in `backend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6842ab02ac58832392fdcd95edcd63de