### PR TITLE
Ajout table unites et tri des ingrédients

### DIFF
--- a/backend/migrations/1750000000002_create-unites-table.js
+++ b/backend/migrations/1750000000002_create-unites-table.js
@@ -1,0 +1,69 @@
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+  pgm.createTable('unites', {
+    id: 'uuid PRIMARY KEY',
+    nom: { type: 'text', notNull: true, unique: true }
+  });
+
+  pgm.addColumn('ingredients', {
+    unite_id: {
+      type: 'uuid',
+      references: 'unites',
+      onDelete: 'set null'
+    }
+  });
+
+  pgm.addColumn('recipe_ingredients', {
+    unite_id: {
+      type: 'uuid',
+      references: 'unites',
+      onDelete: 'set null'
+    }
+  });
+
+  pgm.sql(`
+    INSERT INTO unites(id, nom)
+    SELECT gen_random_uuid(), unite FROM (
+      SELECT unite FROM ingredients
+      UNION
+      SELECT unite FROM recipe_ingredients
+    ) u
+    WHERE unite IS NOT NULL
+    GROUP BY unite
+  `);
+
+  pgm.sql(`
+    UPDATE ingredients SET unite_id = u.id
+    FROM unites u
+    WHERE ingredients.unite = u.nom
+  `);
+
+  pgm.sql(`
+    UPDATE recipe_ingredients SET unite_id = u.id
+    FROM unites u
+    WHERE recipe_ingredients.unite = u.nom
+  `);
+
+  pgm.dropColumn('ingredients', 'unite');
+  pgm.dropColumn('recipe_ingredients', 'unite');
+};
+
+exports.down = pgm => {
+  pgm.addColumn('ingredients', { unite: { type: 'text' } });
+  pgm.addColumn('recipe_ingredients', { unite: { type: 'text', notNull: true } });
+
+  pgm.sql(`
+    UPDATE ingredients i SET unite = u.nom
+    FROM unites u WHERE i.unite_id = u.id
+  `);
+
+  pgm.sql(`
+    UPDATE recipe_ingredients ri SET unite = u.nom
+    FROM unites u WHERE ri.unite_id = u.id
+  `);
+
+  pgm.dropColumn('ingredients', 'unite_id');
+  pgm.dropColumn('recipe_ingredients', 'unite_id');
+  pgm.dropTable('unites');
+};

--- a/backend/src/unite.ts
+++ b/backend/src/unite.ts
@@ -1,0 +1,15 @@
+import { randomUUID } from 'crypto';
+import { PoolClient } from 'pg';
+
+export async function findOrCreateUnite(client: PoolClient, nom?: string): Promise<string | null> {
+  if (!nom) {
+    return null;
+  }
+  let result = await client.query('SELECT id FROM unites WHERE nom = $1', [nom]);
+  if (result.rows.length > 0) {
+    return result.rows[0].id;
+  }
+  const id = randomUUID();
+  await client.query('INSERT INTO unites (id, nom) VALUES ($1, $2)', [id, nom]);
+  return id;
+}

--- a/backend/tests/unite.test.ts
+++ b/backend/tests/unite.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { findOrCreateUnite } from '../src/unite';
+
+vi.mock('crypto', async () => {
+  const actual = await vi.importActual<typeof import('crypto')>('crypto');
+  return { ...actual, randomUUID: vi.fn(() => 'uuid') };
+});
+
+describe('findOrCreateUnite', () => {
+  const client = { query: vi.fn() } as unknown as { query: vi.Mock };
+
+  beforeEach(() => {
+    client.query.mockReset();
+  });
+
+  it('returns null when name is missing', async () => {
+    const res = await findOrCreateUnite(client, undefined);
+    expect(res).toBeNull();
+    expect(client.query).not.toHaveBeenCalled();
+  });
+
+  it('returns existing id if found', async () => {
+    client.query.mockResolvedValueOnce({ rows: [{ id: 'abc' }] });
+    const res = await findOrCreateUnite(client, 'kg');
+    expect(res).toBe('abc');
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('inserts when not found', async () => {
+    client.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({});
+    const res = await findOrCreateUnite(client, 'kg');
+    expect(res).toBe('uuid');
+    expect(client.query).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Notes
- Création d’une migration pour stocker les unités dans la nouvelle table `unites`
- Ajout d’un helper `findOrCreateUnite` utilisé lors de la création d’ingrédients et de recettes
- Mise à jour des routes pour insérer et lire les unités via cette table
- Les ingrédients d’une recette sont maintenant renvoyés avec un tri plaçant l’ingrédient principal puis secondaire avant les autres
- Ajout des tests unitaires pour le helper et adaptation des tests existants

## Résultats des commandes
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842cb13a11c832385459df85bc1f787