### PR TITLE
feat: unit typeahead support

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 import cors from 'cors';
 import recipeRoutes from './routes/recipes';
 import ingredientRoutes from './routes/ingredients';
+import uniteRoutes from './routes/unites';
 
 dotenv.config();
 
@@ -13,6 +14,7 @@ app.use(express.json());
 app.use(cors());
 app.use('/recipes', recipeRoutes);
 app.use('/ingredients', ingredientRoutes);
+app.use('/unites', uniteRoutes);
 
 app.get('/', (req, res) => {
   res.send('Repas Planner API');

--- a/backend/src/routes/unites.ts
+++ b/backend/src/routes/unites.ts
@@ -1,0 +1,25 @@
+import express, { Request, Response, NextFunction } from 'express';
+import pool from '../db';
+
+const router = express.Router();
+
+// GET /unites - search units by name
+router.get('/', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  const search = (req.query.search as string) || '';
+  try {
+    const { rows } = await pool.query(
+      `SELECT id, nom
+       FROM unites
+       WHERE nom ILIKE $1
+       ORDER BY nom
+       LIMIT 10`,
+      [`%${search}%`]
+    );
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;
+

--- a/backend/tests/app.test.ts
+++ b/backend/tests/app.test.ts
@@ -33,3 +33,14 @@ describe('GET /recipes/:id/ingredients', () => {
     expect(mockedQuery).toHaveBeenCalled();
   });
 });
+
+describe('GET /unites', () => {
+  it('searches units', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 'u1', nom: 'kg' }] });
+    const res = await request(app).get('/unites?search=k');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 'u1', nom: 'kg' }]);
+    expect(mockedQuery).toHaveBeenCalled();
+  });
+});
+

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -36,6 +36,11 @@ export interface RecipeIngredient {
   unite: string
 }
 
+export interface Unite {
+  id: string
+  nom: string
+}
+
 export async function fetchRecipes() {
   const res = await globalThis.fetch(`${API_BASE_URL}/recipes`)
   if (!res.ok) {
@@ -80,6 +85,16 @@ export async function searchIngredients(search: string): Promise<Ingredient[]> {
   const res = await globalThis.fetch(`${API_BASE_URL}/ingredients?${params.toString()}`)
   if (!res.ok) {
     throw new Error('Failed to fetch ingredients')
+  }
+  return res.json()
+}
+
+export async function searchUnites(search: string): Promise<Unite[]> {
+  const params = new globalThis.URLSearchParams()
+  params.set('search', search)
+  const res = await globalThis.fetch(`${API_BASE_URL}/unites?${params.toString()}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch unites')
   }
   return res.json()
 }

--- a/frontend/src/components/IngredientInput.test.ts
+++ b/frontend/src/components/IngredientInput.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, type Mock } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import IngredientInput from './IngredientInput.vue'
+import * as api from '../api'
+
+vi.mock('../api')
+
+describe('IngredientInput', () => {
+  it('shows suggestions and allows picking', async () => {
+    ;(api.searchIngredients as unknown as Mock).mockResolvedValue([{ id: 'i1', nom: 'Tomate', unite: 'kg' }])
+    ;(api.searchUnites as unknown as Mock).mockResolvedValue([{ id: 'u1', nom: 'kg' }])
+
+    const wrapper = mount(IngredientInput, {
+      props: { modelValue: { nom: '', quantite: '', unite: '' } }
+    })
+
+    await wrapper.get('input[placeholder="Ingrédient"]').setValue('tom')
+    await flushPromises()
+    const itemsIng = wrapper.findAll('ul li').map(li => li.text())
+    expect(itemsIng).toContain('Tomate')
+    const events = wrapper.emitted('update:modelValue') as unknown[][]
+    expect((events[0][0] as { nom: string }).nom).toBe('tom')
+
+    await wrapper.get('input[placeholder="Unité"]').setValue('k')
+    await flushPromises()
+    const items = wrapper.findAll('ul li').map(li => li.text())
+    expect(items).toContain('kg')
+    await wrapper.get('ul li').trigger('click')
+    const value = wrapper.emitted('update:modelValue')![1][0] as { unite: string }
+    expect(value.unite).toBe('kg')
+  })
+
+  it('handles unit search errors', async () => {
+    ;(api.searchIngredients as unknown as Mock).mockResolvedValue([])
+    ;(api.searchUnites as unknown as Mock).mockRejectedValue(new Error('fail'))
+
+    const wrapper = mount(IngredientInput, {
+      props: { modelValue: { nom: '', quantite: '', unite: '' } }
+    })
+
+    await wrapper.get('input[placeholder="Unité"]').setValue('k')
+    await flushPromises()
+    expect(wrapper.findAll('ul li')).toHaveLength(0)
+  })
+})
+


### PR DESCRIPTION
## Summary
- search units in the backend
- wire `/unites` API route in the app
- add unit search function to the frontend API
- improve ingredient input with unit typeahead
- test unit typeahead component

## Testing
- `npm test` in `frontend`
- `npm run lint` in `frontend`
- `npm run build` in `frontend`
- `npm test` in `backend`
- `npm run build` in `backend`
- `npm run lint` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6842d3b9cc108323b50e6bd66a1bbcab