### PR TITLE
Implement context-aware back navigation

### DIFF
--- a/frontend/src/pages/RecipeDetailPage.test.ts
+++ b/frontend/src/pages/RecipeDetailPage.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, type Mock, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createRouter, createWebHistory } from 'vue-router'
+import RecipeDetailPage from './RecipeDetailPage.vue'
+import { routes } from '../router'
+import * as api from '../api'
+
+vi.mock('../api')
+
+const recipe = {
+  id: 'r1',
+  nom: 'Recette',
+  instructions: 'Inst',
+  image_url: 'img',
+  ingredient_principal_id: null,
+  ingredient_secondaire_id: null
+}
+
+async function setup() {
+  const router = createRouter({ history: createWebHistory(), routes })
+  router.push('/recipes/r1')
+  await router.isReady()
+  const wrapper = mount(RecipeDetailPage, { global: { plugins: [router] } })
+  return { wrapper, router }
+}
+
+describe('RecipeDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('shows recipe and goes back', async () => {
+    ;(api.fetchRecipe as unknown as Mock).mockResolvedValue(recipe)
+    ;(api.fetchRecipeIngredients as unknown as Mock).mockResolvedValue([])
+    const { wrapper, router } = await setup()
+    await flushPromises()
+    const backSpy = vi.spyOn(router, 'back')
+    await wrapper.get('button').trigger('click')
+    expect(backSpy).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Recette')
+  })
+
+  it('does not show image when none', async () => {
+    ;(api.fetchRecipe as unknown as Mock).mockResolvedValue({ ...recipe, image_url: null })
+    ;(api.fetchRecipeIngredients as unknown as Mock).mockResolvedValue([])
+    const { wrapper } = await setup()
+    await flushPromises()
+    expect(wrapper.find('img').exists()).toBe(false)
+  })
+
+  it('removes recipe when confirmed', async () => {
+    ;(api.fetchRecipe as unknown as Mock).mockResolvedValue(recipe)
+    ;(api.fetchRecipeIngredients as unknown as Mock).mockResolvedValue([])
+    ;(api.deleteRecipe as unknown as Mock).mockResolvedValue({})
+    vi.spyOn(globalThis, 'confirm').mockReturnValue(true)
+    const { wrapper, router } = await setup()
+    await flushPromises()
+    const pushSpy = vi.spyOn(router, 'push')
+    await wrapper.findAll('button')[1].trigger('click')
+    expect(api.deleteRecipe).toHaveBeenCalledWith('r1')
+    expect(pushSpy).toHaveBeenCalledWith('/recipes')
+  })
+
+  it('cancels remove when not confirmed', async () => {
+    ;(api.fetchRecipe as unknown as Mock).mockResolvedValue(recipe)
+    ;(api.fetchRecipeIngredients as unknown as Mock).mockResolvedValue([])
+    vi.spyOn(globalThis, 'confirm').mockReturnValue(false)
+    const { wrapper } = await setup()
+    await flushPromises()
+    await wrapper.findAll('button')[1].trigger('click')
+    expect(api.deleteRecipe).not.toHaveBeenCalled()
+  })
+
+  it('handles delete errors', async () => {
+    ;(api.fetchRecipe as unknown as Mock).mockResolvedValue(recipe)
+    ;(api.fetchRecipeIngredients as unknown as Mock).mockResolvedValue([])
+    ;(api.deleteRecipe as unknown as Mock).mockRejectedValue(new Error('fail'))
+    vi.spyOn(globalThis, 'confirm').mockReturnValue(true)
+    const { wrapper } = await setup()
+    await flushPromises()
+    await wrapper.findAll('button')[1].trigger('click')
+    expect(api.deleteRecipe).toHaveBeenCalled()
+  })
+
+  it('returns early when recipe is null', async () => {
+    ;(api.fetchRecipe as unknown as Mock).mockResolvedValue(recipe)
+    ;(api.fetchRecipeIngredients as unknown as Mock).mockResolvedValue([])
+    const { wrapper } = await setup()
+    await flushPromises()
+    // set recipe to null and attempt remove
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(wrapper.vm as any).recipe = null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (wrapper.vm as any).remove()
+    expect(api.deleteRecipe).not.toHaveBeenCalled()
+  })
+
+  it('handles fetch errors', async () => {
+    ;(api.fetchRecipe as unknown as Mock).mockRejectedValue(new Error('fail'))
+    ;(api.fetchRecipeIngredients as unknown as Mock).mockRejectedValue(new Error('fail'))
+    const { wrapper } = await setup()
+    await flushPromises()
+    expect(wrapper.text()).toBe('')
+  })
+})

--- a/frontend/src/pages/RecipeDetailPage.vue
+++ b/frontend/src/pages/RecipeDetailPage.vue
@@ -35,12 +35,13 @@ async function remove() {
     v-if="recipe"
     class="max-w-2xl mx-auto"
   >
-    <RouterLink
-      to="/recipes"
+    <button
+      type="button"
       class="text-blue-600"
+      @click="router.back()"
     >
       &larr; Retour
-    </RouterLink>
+    </button>
     <h1 class="text-3xl font-bold my-4">
       {{ recipe.nom }}
     </h1>


### PR DESCRIPTION
## Summary
- make RecipeDetailPage back button return to previous page
- add comprehensive tests for RecipeDetailPage

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842e7e8b44883239d239040c8ab9ccb