### PR TITLE
Implement last-used priority in menu

### DIFF
--- a/backend/src/menu.ts
+++ b/backend/src/menu.ts
@@ -2,6 +2,7 @@ export interface RecipeRow {
   id: string
   ingredient_principal_id: string | null
   ingredient_secondaire_id: string | null
+  last_used: string | null
 }
 
 export interface Selection {
@@ -17,7 +18,14 @@ export interface MenuEntry {
 export function generateMenuEntries(recipes: RecipeRow[], selection: Selection): MenuEntry[] {
   const used = new Set<string>()
   const result: MenuEntry[] = []
-  const pool = recipes.slice()
+  const pool = recipes
+    .slice()
+    .sort((a, b) => {
+      if (a.last_used === b.last_used) return 0
+      if (a.last_used === null) return -1
+      if (b.last_used === null) return 1
+      return a.last_used.localeCompare(b.last_used)
+    })
   for (const jour of Object.keys(selection)) {
     for (const moment of ['dejeuner', 'diner'] as const) {
       if (!selection[jour][moment]) continue

--- a/backend/tests/menu.test.ts
+++ b/backend/tests/menu.test.ts
@@ -4,14 +4,34 @@ import { generateMenuEntries } from '../src/menu'
 describe('generateMenuEntries', () => {
   it('avoids ingredient repetition', () => {
     const recipes = [
-      { id: 'r1', ingredient_principal_id: 'i1', ingredient_secondaire_id: null },
-      { id: 'r2', ingredient_principal_id: 'i1', ingredient_secondaire_id: null },
-      { id: 'r3', ingredient_principal_id: 'i2', ingredient_secondaire_id: null }
+      { id: 'r1', ingredient_principal_id: 'i1', ingredient_secondaire_id: null, last_used: null },
+      { id: 'r2', ingredient_principal_id: 'i1', ingredient_secondaire_id: null, last_used: null },
+      { id: 'r3', ingredient_principal_id: 'i2', ingredient_secondaire_id: null, last_used: null }
     ]
     const sel = { lundi: { dejeuner: true, diner: true } }
     const res = generateMenuEntries(recipes, sel)
     expect(res).toHaveLength(2)
     expect(res[0].recipe_id).toBe('r1')
     expect(res[1].recipe_id).toBe('r3')
+  })
+
+  it('prioritizes recipes least recently used', () => {
+    const recipes = [
+      { id: 'r1', ingredient_principal_id: 'i1', ingredient_secondaire_id: null, last_used: '2024-W05' },
+      { id: 'r2', ingredient_principal_id: 'i2', ingredient_secondaire_id: null, last_used: '2024-W01' }
+    ]
+    const sel = { lundi: { dejeuner: true, diner: false } }
+    const res = generateMenuEntries(recipes, sel)
+    expect(res[0].recipe_id).toBe('r2')
+  })
+
+  it('fills with null when no recipe fits', () => {
+    const recipes = [
+      { id: 'r1', ingredient_principal_id: 'i1', ingredient_secondaire_id: null, last_used: null }
+    ]
+    const sel = { lundi: { dejeuner: true, diner: true } }
+    const res = generateMenuEntries(recipes, sel)
+    expect(res[0].recipe_id).toBe('r1')
+    expect(res[1].recipe_id).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- include `last_used` info when generating weekly menus
- order recipes by this value so neglected recipes appear first
- update menu entries query to fetch last usage week
- extend unit tests for new sorting logic

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842efd6cc708323bcff18185e7c6a5b