### PR TITLE
Update menu rule for secondary ingredient

### DIFF
--- a/backend/tests/menu.test.ts
+++ b/backend/tests/menu.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { generateMenuEntries } from '../src/menu'
 
 describe('generateMenuEntries', () => {
-  it('avoids ingredient repetition', () => {
+  it('avoids main ingredient repetition', () => {
     const recipes = [
       { id: 'r1', ingredient_principal_id: 'i1', ingredient_secondaire_id: null, last_used: null },
       { id: 'r2', ingredient_principal_id: 'i1', ingredient_secondaire_id: null, last_used: null },
@@ -13,6 +13,21 @@ describe('generateMenuEntries', () => {
     expect(res).toHaveLength(2)
     expect(res[0].recipe_id).toBe('r1')
     expect(res[1].recipe_id).toBe('r3')
+  })
+
+  it('allows secondary ingredient twice at most', () => {
+    const recipes = [
+      { id: 'r1', ingredient_principal_id: 'i1', ingredient_secondaire_id: 's1', last_used: null },
+      { id: 'r2', ingredient_principal_id: 'i2', ingredient_secondaire_id: 's1', last_used: null },
+      { id: 'r3', ingredient_principal_id: 'i3', ingredient_secondaire_id: 's1', last_used: null },
+      { id: 'r4', ingredient_principal_id: 'i4', ingredient_secondaire_id: 's2', last_used: null }
+    ]
+    const sel = {
+      lundi: { dejeuner: true, diner: true },
+      mardi: { dejeuner: true, diner: true }
+    }
+    const res = generateMenuEntries(recipes, sel)
+    expect(res.map(r => r.recipe_id)).toEqual(['r1', 'r2', 'r4', null])
   })
 
   it('prioritizes recipes least recently used', () => {


### PR DESCRIPTION
## Summary
- enforce unique main ingredients while allowing secondary ingredients twice per week
- test menu generation with secondary ingredient repeat

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68430ed8fad48323bdc267f2bfb74aac