### PR TITLE
Affichage mignature recette

### DIFF
--- a/frontend/src/assets/placeholder.svg
+++ b/frontend/src/assets/placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#e2e8f0"/>
+  <text x="50" y="50" fill="#94a3b8" dominant-baseline="middle" text-anchor="middle" font-size="12">No Image</text>
+</svg>

--- a/frontend/src/pages/RecipesPage.test.ts
+++ b/frontend/src/pages/RecipesPage.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, type Mock } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createRouter, createWebHistory } from 'vue-router'
+import RecipesPage from './RecipesPage.vue'
+import { routes } from '../router'
+import * as api from '../api'
+
+vi.mock('../api')
+
+async function setup() {
+  const router = createRouter({ history: createWebHistory(), routes })
+  router.push('/recipes')
+  await router.isReady()
+  return mount(RecipesPage, { global: { plugins: [router] } })
+}
+
+describe('RecipesPage', () => {
+  it('shows images and placeholder', async () => {
+    ;(api.fetchRecipes as unknown as Mock).mockResolvedValue([
+      { id: 'r1', nom: 'A', instructions: null, image_url: 'img' },
+      { id: 'r2', nom: 'B', instructions: null, image_url: null }
+    ])
+    const wrapper = await setup()
+    await flushPromises()
+    const imgs = wrapper.findAll('img')
+    expect(imgs).toHaveLength(2)
+    expect(imgs[0].attributes('src')).toBe('img')
+    expect(imgs[1].attributes('src')).not.toBe('img')
+  })
+})

--- a/frontend/src/pages/RecipesPage.vue
+++ b/frontend/src/pages/RecipesPage.vue
@@ -2,8 +2,14 @@
 import { onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import { fetchRecipes } from '../api'
+import placeholderImg from '../assets/placeholder.svg'
 
-interface RecipeSummary { id: string; nom: string; instructions: string | null }
+interface RecipeSummary {
+  id: string
+  nom: string
+  instructions: string | null
+  image_url: string | null
+}
 const recipes = ref<RecipeSummary[]>([])
 
 onMounted(async () => {
@@ -34,6 +40,11 @@ onMounted(async () => {
         :to="`/recipes/${recipe.id}`"
         class="bg-white rounded shadow p-4 block hover:bg-gray-50"
       >
+        <img
+          :src="recipe.image_url || placeholderImg"
+          alt="Recipe image"
+          class="w-full h-32 object-cover rounded mb-2"
+        >
         <h2 class="font-medium text-lg mb-1">
           {{ recipe.nom }}
         </h2>


### PR DESCRIPTION
## Summary
- display recipe thumbnail in the recipes list
- add placeholder image for recipes without picture
- test recipe thumbnail display

## Testing
- `npm run lint`
- `npm run test`
- `npx vitest run --coverage`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684310b777ec8323a7ef0983abb0c193