### PR TITLE
Serve frontend on base URL

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -15,14 +15,14 @@ const frontendPath = process.env.FRONTEND_PATH || path.join(__dirname, 'public')
 
 app.use(express.json());
 app.use(cors());
-app.use(express.static(frontendPath, { index: false }));
+app.use(express.static(frontendPath));
 app.use('/recipes', recipeRoutes);
 app.use('/ingredients', ingredientRoutes);
 app.use('/unites', uniteRoutes);
 app.use('/menus', menuRoutes);
 
-app.get('/', (req, res) => {
-  res.send('Repas Planner API');
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(frontendPath, 'index.html'));
 });
 
 /* c8 ignore next 5 */

--- a/backend/tests/app.test.ts
+++ b/backend/tests/app.test.ts
@@ -32,11 +32,17 @@ afterAll(() => {
   rmSync(tempDir, { recursive: true, force: true });
 });
 
-describe('GET /', () => {
-  it('returns API message', async () => {
+describe('Frontend serving', () => {
+  it('serves index.html at root', async () => {
     const res = await request(app).get('/');
     expect(res.status).toBe(200);
-    expect(res.text).toBe('Repas Planner API');
+    expect(res.text).toBe('hello');
+  });
+
+  it('serves index.html for other paths', async () => {
+    const res = await request(app).get('/random');
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('hello');
   });
 });
 


### PR DESCRIPTION
## Summary
- serve compiled frontend from Express app
- adjust app tests for new behavior

## Testing
- `npm -C backend run lint`
- `npm -C backend run test`
- `npm -C backend run build`

------
https://chatgpt.com/codex/tasks/task_e_684357c5876c83238c7b591ed41c5788