### PR TITLE
Improve entrypoint logging

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,15 @@
 #!/bin/sh
 set -e
 
+printf 'Entrypoint starting at %s\n' "$(date)"
+printf 'NODE VERSION: %s\n' "$(node -v 2>/dev/null || echo 'node not installed')"
+printf 'NODE_ENV=%s\n' "${NODE_ENV:-}"
+if [ -n "$DATABASE_URL" ]; then
+  printf 'Using DATABASE_URL=%s\n' "$DATABASE_URL"
+else
+  printf 'DATABASE_URL not set\n'
+fi
+
 TIMEOUT=120
 START=$(date +%s)
 
@@ -12,6 +21,7 @@ until pg_isready -d "$DATABASE_URL" >/dev/null 2>&1; do
     echo "Database not ready after $TIMEOUT seconds" >&2
     exit 1
   fi
+  printf 'Database not ready yet, waiting 2s...\n'
   sleep 2
 done
 
@@ -20,5 +30,6 @@ printf 'Database ready. Running migrations...\n'
 npx node-pg-migrate
 
 printf 'Starting application...\n'
+printf 'Exec command: %s\n' "$*"
 exec "$@"
 


### PR DESCRIPTION
## Summary
- add more startup messages in `entrypoint.sh`
- log retries while waiting for the database
- log command executed at the end

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684360d4cdb483238876a7ed11284cd7