### PR TITLE
Fix missing postgres client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN npm run build
 
 # Production image
 FROM node:20-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app/backend
 COPY backend/package*.json ./
 RUN npm ci


### PR DESCRIPTION
## Summary
- install postgres client so `pg_isready` works in the entrypoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684363277df8832393bb0293a1fc35ff