### PR TITLE
Fix API base URL for production

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fetchShoppingList, exportRecipes, importRecipes } from './api'
+import { fetchShoppingList, exportRecipes, importRecipes, getApiBaseUrl } from './api'
 
 const data = [{ id: 'i1', nom: 'Beurre', quantite: '700', unite: 'g' }]
 
@@ -31,5 +31,16 @@ describe('exportRecipes/importRecipes', () => {
     const call = (globalThis.fetch as unknown as vi.Mock).mock.calls[1]
     expect(call[0]).toBe('http://localhost:3000/api/recipes/import')
     expect(call[1].method).toBe('POST')
+  })
+})
+
+describe('getApiBaseUrl', () => {
+  it('returns dev url when PROD is false', () => {
+    expect(getApiBaseUrl({ PROD: false })).toBe('http://localhost:3000/api')
+  })
+
+  it('returns location url when PROD is true', () => {
+    vi.stubGlobal('location', { origin: 'https://site.example' })
+    expect(getApiBaseUrl({ PROD: true })).toBe('https://site.example/api')
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,8 @@
-export const API_BASE_URL = 'http://localhost:3000/api'
+export function getApiBaseUrl(env: { PROD: boolean } = import.meta.env) {
+  return env.PROD ? `${globalThis.location.origin}/api` : 'http://localhost:3000/api'
+}
+
+export const API_BASE_URL = getApiBaseUrl()
 
 export interface RecipePayload {
   nom: string


### PR DESCRIPTION
## Summary
- detect production environment in `api.ts`
- test both PROD and dev cases in `api.test.ts`

## Testing
- `npm run lint` in frontend and backend
- `npm test` in frontend and backend
- `npm run build` in frontend and backend

------
https://chatgpt.com/codex/tasks/task_e_68436c4831588323b8240da12c03d1b8