### PR TITLE
Add simple authentication

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "repas-backend",
       "version": "1.0.0",
       "dependencies": {
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -16,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.28.0",
+        "@types/cookie-parser": "^1.4.9",
         "@types/cors": "^2.8.18",
         "@types/express": "^5.0.2",
         "@types/pg": "^8.15.4",
@@ -1331,6 +1333,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cors": {
       "version": "2.8.18",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.18.tgz",
@@ -2479,6 +2491,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,14 +13,16 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
-    "pg": "^8.11.1",
-    "node-pg-migrate": "^7.1.0"
+    "node-pg-migrate": "^7.1.0",
+    "pg": "^8.11.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
+    "@types/cookie-parser": "^1.4.9",
     "@types/cors": "^2.8.18",
     "@types/express": "^5.0.2",
     "@types/pg": "^8.15.4",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,11 +1,18 @@
 import express from 'express';
 import dotenv from 'dotenv';
 import cors from 'cors';
+import cookieParser from 'cookie-parser';
 import path from 'path';
 import recipeRoutes from './routes/recipes';
 import ingredientRoutes from './routes/ingredients';
 import uniteRoutes from './routes/unites';
 import menuRoutes from './routes/menus';
+import {
+  authMiddleware,
+  loginRoute,
+  logoutRoute,
+  authRequiredInfo
+} from './auth';
 
 dotenv.config();
 
@@ -15,6 +22,11 @@ const frontendPath = process.env.FRONTEND_PATH || path.join(__dirname, 'public')
 
 app.use(express.json());
 app.use(cors());
+app.use(cookieParser());
+app.post('/api/login', loginRoute);
+app.post('/api/logout', logoutRoute);
+app.get('/api/auth-required', authRequiredInfo);
+app.use('/api', authMiddleware);
 app.use(express.static(frontendPath));
 app.use('/api/recipes', recipeRoutes);
 app.use('/api/ingredients', ingredientRoutes);

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -1,0 +1,47 @@
+import { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+
+const sessions = new Set<string>();
+
+export function isAuthEnabled() {
+  return Boolean(process.env.AUTH_USERNAME && process.env.AUTH_PASSWORD);
+}
+
+export function authMiddleware(req: Request, res: Response, next: NextFunction) {
+  if (!isAuthEnabled()) return next();
+  const token = req.cookies?.auth;
+  if (token && sessions.has(token)) {
+    return next();
+  }
+  res.status(401).end();
+}
+
+export function loginRoute(req: Request, res: Response) {
+  if (!isAuthEnabled()) {
+    res.status(404).end();
+    return;
+  }
+  const { username, password } = req.body as { username?: string; password?: string };
+  if (
+    username === process.env.AUTH_USERNAME &&
+    password === process.env.AUTH_PASSWORD
+  ) {
+    const token = randomUUID();
+    sessions.add(token);
+    res.cookie('auth', token, { httpOnly: true });
+    res.json({ success: true });
+  } else {
+    res.status(401).json({ error: 'Invalid credentials' });
+  }
+}
+
+export function logoutRoute(req: Request, res: Response) {
+  const token = req.cookies?.auth;
+  if (token) sessions.delete(token);
+  res.clearCookie('auth');
+  res.json({ success: true });
+}
+
+export function authRequiredInfo(_req: Request, res: Response) {
+  res.json({ required: isAuthEnabled() });
+}

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -1,0 +1,66 @@
+import request from 'supertest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import os from 'os';
+import path from 'path';
+
+vi.mock('../src/db', () => {
+  return { default: { query: vi.fn() } };
+});
+
+let app: typeof import('../src/app').default;
+import db from '../src/db';
+const q = (db as { query: vi.Mock }).query;
+
+let dir: string;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(os.tmpdir(), 'front-'));
+  writeFileSync(path.join(dir, 'index.html'), '');
+  process.env.FRONTEND_PATH = dir;
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  q.mockReset();
+  delete process.env.AUTH_USERNAME;
+  delete process.env.AUTH_PASSWORD;
+});
+
+describe('auth disabled', () => {
+  beforeEach(async () => {
+    app = (await import('../src/app')).default;
+  });
+  it('allows requests', async () => {
+    q.mockResolvedValueOnce({ rows: [] });
+    const res = await request(app).get('/api/recipes');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('auth enabled', () => {
+  beforeEach(async () => {
+    process.env.AUTH_USERNAME = 'u';
+    process.env.AUTH_PASSWORD = 'p';
+    app = (await import('../src/app')).default;
+  });
+  it('rejects unauthenticated', async () => {
+    const res = await request(app).get('/api/recipes');
+    expect(res.status).toBe(401);
+  });
+  it('logs in and accesses route', async () => {
+    const login = await request(app).post('/api/login').send({ username: 'u', password: 'p' });
+    expect(login.status).toBe(200);
+    const cookie = login.headers['set-cookie'][0];
+    q.mockResolvedValueOnce({ rows: [] });
+    const res = await request(app).get('/api/recipes').set('Cookie', cookie);
+    expect(res.status).toBe(200);
+  });
+  it('rejects invalid login', async () => {
+    const login = await request(app).post('/api/login').send({ username: 'x', password: 'y' });
+    expect(login.status).toBe(401);
+  });
+});

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fetchShoppingList, exportRecipes, importRecipes, getApiBaseUrl } from './api'
+import { fetchShoppingList, exportRecipes, importRecipes, getApiBaseUrl, checkAuthRequired, login } from './api'
 
 const data = [{ id: 'i1', nom: 'Beurre', quantite: '700', unite: 'g' }]
 
@@ -11,7 +11,7 @@ describe('fetchShoppingList', () => {
   it('returns ingredients', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(data) }))
     const res = await fetchShoppingList('w')
-    expect(globalThis.fetch).toHaveBeenCalledWith('http://localhost:3000/api/menus/w/shopping-list')
+    expect(globalThis.fetch).toHaveBeenCalledWith('http://localhost:3000/api/menus/w/shopping-list', { credentials: 'include' })
     expect(res).toEqual(data)
   })
 
@@ -25,7 +25,7 @@ describe('exportRecipes/importRecipes', () => {
   it('calls export and import endpoints', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) }))
     await exportRecipes()
-    expect(globalThis.fetch).toHaveBeenCalledWith('http://localhost:3000/api/recipes/export')
+    expect(globalThis.fetch).toHaveBeenCalledWith('http://localhost:3000/api/recipes/export', { credentials: 'include' })
     ;(globalThis.fetch as unknown as vi.Mock).mockResolvedValue({ ok: true })
     await importRecipes([])
     const call = (globalThis.fetch as unknown as vi.Mock).mock.calls[1]
@@ -42,5 +42,21 @@ describe('getApiBaseUrl', () => {
   it('returns location url when PROD is true', () => {
     vi.stubGlobal('location', { origin: 'https://site.example' })
     expect(getApiBaseUrl({ PROD: true })).toBe('https://site.example/api')
+  })
+})
+
+describe('auth helpers', () => {
+  it('checkAuthRequired fetches flag', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve({ required: true }) }))
+    const res = await checkAuthRequired()
+    expect(res.required).toBe(true)
+  })
+
+  it('login posts credentials', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }))
+    await login('a', 'b')
+    const call = (globalThis.fetch as unknown as vi.Mock).mock.calls[0]
+    expect(call[0]).toBe('http://localhost:3000/api/login')
+    expect(call[1].credentials).toBe('include')
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,8 +1,34 @@
+/* global RequestInfo, RequestInit */
 export function getApiBaseUrl(env: { PROD: boolean } = import.meta.env) {
   return env.PROD ? `${globalThis.location.origin}/api` : 'http://localhost:3000/api'
 }
 
 export const API_BASE_URL = getApiBaseUrl()
+
+export async function apiFetch(input: RequestInfo, init: RequestInit = {}) {
+  return globalThis.fetch(input, { credentials: 'include', ...init })
+}
+
+export async function checkAuthRequired() {
+  const res = await apiFetch(`${API_BASE_URL}/auth-required`)
+  return res.json() as Promise<{ required: boolean }>
+}
+
+export async function login(username: string, password: string) {
+  const res = await apiFetch(`${API_BASE_URL}/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  })
+  if (!res.ok) throw new Error('Login failed')
+  return res.json()
+}
+
+/* global localStorage */
+export async function logout() {
+  await apiFetch(`${API_BASE_URL}/logout`, { method: 'POST' })
+  localStorage.removeItem('loggedIn')
+}
 
 export interface RecipePayload {
   nom: string
@@ -48,7 +74,7 @@ export interface Unite {
 }
 
 export async function fetchRecipes() {
-  const res = await globalThis.fetch(`${API_BASE_URL}/recipes`)
+  const res = await apiFetch(`${API_BASE_URL}/recipes`)
   if (!res.ok) {
     throw new Error('Failed to fetch recipes')
   }
@@ -56,7 +82,7 @@ export async function fetchRecipes() {
 }
 
 export async function fetchRecipe(id: string): Promise<Recipe> {
-  const res = await globalThis.fetch(`${API_BASE_URL}/recipes/${id}`)
+  const res = await apiFetch(`${API_BASE_URL}/recipes/${id}`)
   if (!res.ok) {
     throw new Error('Failed to fetch recipe')
   }
@@ -64,7 +90,7 @@ export async function fetchRecipe(id: string): Promise<Recipe> {
 }
 
 export async function fetchRecipeIngredients(id: string): Promise<RecipeIngredient[]> {
-  const res = await globalThis.fetch(`${API_BASE_URL}/recipes/${id}/ingredients`)
+  const res = await apiFetch(`${API_BASE_URL}/recipes/${id}/ingredients`)
   if (!res.ok) {
     throw new Error('Failed to fetch ingredients')
   }
@@ -72,7 +98,7 @@ export async function fetchRecipeIngredients(id: string): Promise<RecipeIngredie
 }
 
 export async function createRecipe(payload: RecipePayload) {
-  const res = await globalThis.fetch(`${API_BASE_URL}/recipes`, {
+  const res = await apiFetch(`${API_BASE_URL}/recipes`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
@@ -86,7 +112,7 @@ export async function createRecipe(payload: RecipePayload) {
 }
 
 export async function updateRecipe(id: string, payload: RecipePayload) {
-  const res = await globalThis.fetch(`${API_BASE_URL}/recipes/${id}`, {
+  const res = await apiFetch(`${API_BASE_URL}/recipes/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
@@ -98,7 +124,7 @@ export async function updateRecipe(id: string, payload: RecipePayload) {
 }
 
 export async function deleteRecipe(id: string) {
-  const res = await globalThis.fetch(`${API_BASE_URL}/recipes/${id}`, {
+  const res = await apiFetch(`${API_BASE_URL}/recipes/${id}`, {
     method: 'DELETE'
   })
   if (!res.ok) {
@@ -109,7 +135,7 @@ export async function deleteRecipe(id: string) {
 export async function searchIngredients(search: string): Promise<Ingredient[]> {
   const params = new globalThis.URLSearchParams()
   params.set('search', search)
-  const res = await globalThis.fetch(`${API_BASE_URL}/ingredients?${params.toString()}`)
+  const res = await apiFetch(`${API_BASE_URL}/ingredients?${params.toString()}`)
   if (!res.ok) {
     throw new Error('Failed to fetch ingredients')
   }
@@ -119,7 +145,7 @@ export async function searchIngredients(search: string): Promise<Ingredient[]> {
 export async function searchUnites(search: string): Promise<Unite[]> {
   const params = new globalThis.URLSearchParams()
   params.set('search', search)
-  const res = await globalThis.fetch(`${API_BASE_URL}/unites?${params.toString()}`)
+  const res = await apiFetch(`${API_BASE_URL}/unites?${params.toString()}`)
   if (!res.ok) {
     throw new Error('Failed to fetch unites')
   }
@@ -140,13 +166,13 @@ export interface Menu {
 }
 
 export async function fetchMenu(week: string): Promise<Menu> {
-  const res = await globalThis.fetch(`${API_BASE_URL}/menus/${week}`)
+  const res = await apiFetch(`${API_BASE_URL}/menus/${week}`)
   if (!res.ok) throw new Error('Failed to fetch menu')
   return res.json()
 }
 
 export async function generateMenu(week: string, selection: Record<string, { dejeuner: boolean; diner: boolean }>) {
-  const res = await globalThis.fetch(`${API_BASE_URL}/menus/${week}/generate`, {
+  const res = await apiFetch(`${API_BASE_URL}/menus/${week}/generate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ selection })
@@ -163,19 +189,19 @@ export interface ShoppingIngredient {
 }
 
 export async function fetchShoppingList(week: string): Promise<ShoppingIngredient[]> {
-  const res = await globalThis.fetch(`${API_BASE_URL}/menus/${week}/shopping-list`)
+  const res = await apiFetch(`${API_BASE_URL}/menus/${week}/shopping-list`)
   if (!res.ok) throw new Error('Failed to fetch shopping list')
   return res.json()
 }
 
 export async function exportRecipes() {
-  const res = await globalThis.fetch(`${API_BASE_URL}/recipes/export`)
+  const res = await apiFetch(`${API_BASE_URL}/recipes/export`)
   if (!res.ok) throw new Error('Failed to export recipes')
   return res.json()
 }
 
 export async function importRecipes(data: unknown) {
-  const res = await globalThis.fetch(`${API_BASE_URL}/recipes/import`, {
+  const res = await apiFetch(`${API_BASE_URL}/recipes/import`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)

--- a/frontend/src/pages/LoginPage.test.ts
+++ b/frontend/src/pages/LoginPage.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createRouter, createWebHistory } from 'vue-router'
+import LoginPage from './LoginPage.vue'
+import { routes } from '../router'
+import * as api from '../api'
+
+vi.mock('../api')
+
+async function setup() {
+  const router = createRouter({ history: createWebHistory(), routes })
+  router.push('/login')
+  await router.isReady()
+  return mount(LoginPage, { global: { plugins: [router] } })
+}
+
+describe('LoginPage', () => {
+  it('submits credentials', async () => {
+    ;(api.login as unknown as vi.Mock).mockResolvedValue({})
+    const wrapper = await setup()
+    await wrapper.get('form').trigger('submit.prevent')
+    expect(api.login).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { login } from '../api'
+
+/* global localStorage */
+
+const username = ref('')
+const password = ref('')
+const router = useRouter()
+
+async function submit() {
+  try {
+    await login(username.value, password.value)
+    localStorage.setItem('loggedIn', '1')
+    router.push('/recipes')
+  } catch {
+    // ignore invalid credentials
+  }
+}
+</script>
+<template>
+  <form
+    class="max-w-sm mx-auto"
+    @submit.prevent="submit"
+  >
+    <h1 class="text-2xl font-bold mb-4">
+      Connexion
+    </h1>
+    <div class="mb-2">
+      <label class="block mb-1">Nom d'utilisateur</label>
+      <input
+        v-model="username"
+        class="border rounded w-full p-2"
+        required
+      >
+    </div>
+    <div class="mb-4">
+      <label class="block mb-1">Mot de passe</label>
+      <input
+        v-model="password"
+        type="password"
+        class="border rounded w-full p-2"
+        required
+      >
+    </div>
+    <button class="px-3 py-1 bg-blue-600 text-white rounded">
+      Se connecter
+    </button>
+  </form>
+</template>

--- a/frontend/src/router.test.ts
+++ b/frontend/src/router.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { routes } from './router'
+let router: typeof import('./router').default
+import * as api from './api'
+
+/* global localStorage */
+
+vi.mock('./api')
 
 describe('router', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    router = (await import('./router')).default
+  })
   it('should have recipe and menu routes', () => {
     const paths = routes.map(r => r.path)
     expect(paths).toContain('/recipes')
@@ -9,5 +19,40 @@ describe('router', () => {
     expect(paths).toContain('/recipes/:id/edit')
     expect(paths).toContain('/recipes/add')
     expect(paths).toContain('/menu')
+    expect(paths).toContain('/login')
+  })
+
+  it('redirects to login when auth required', async () => {
+    ;(api.checkAuthRequired as unknown as vi.Mock).mockResolvedValue({ required: true })
+    router.push('/')
+    await router.isReady()
+    localStorage.removeItem('loggedIn')
+    await router.push('/recipes')
+    expect(router.currentRoute.value.path).toBe('/login')
+  })
+
+  it('allows login page when auth required', async () => {
+    ;(api.checkAuthRequired as unknown as vi.Mock).mockResolvedValue({ required: true })
+    router.push('/')
+    await router.isReady()
+    await router.push('/login')
+    expect(router.currentRoute.value.path).toBe('/login')
+  })
+
+  it('allows when auth not required', async () => {
+    ;(api.checkAuthRequired as unknown as vi.Mock).mockResolvedValue({ required: false })
+    router.push('/')
+    await router.isReady()
+    await router.push('/recipes')
+    expect(router.currentRoute.value.path).toBe('/recipes')
+  })
+
+  it('allows when logged in', async () => {
+    ;(api.checkAuthRequired as unknown as vi.Mock).mockResolvedValue({ required: true })
+    localStorage.setItem('loggedIn', '1')
+    router.push('/')
+    await router.isReady()
+    await router.push('/recipes')
+    expect(router.currentRoute.value.path).toBe('/recipes')
   })
 })

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -3,6 +3,8 @@ import RecipesPage from './pages/RecipesPage.vue'
 import AddRecipePage from './pages/AddRecipePage.vue'
 import RecipeDetailPage from './pages/RecipeDetailPage.vue'
 import MenuPage from './pages/MenuPage.vue'
+import LoginPage from './pages/LoginPage.vue'
+import { checkAuthRequired } from './api'
 
 export const routes = [
   { path: '/', redirect: '/recipes' },
@@ -10,12 +12,25 @@ export const routes = [
   { path: '/recipes/:id', component: RecipeDetailPage },
   { path: '/recipes/:id/edit', component: AddRecipePage },
   { path: '/recipes/add', component: AddRecipePage },
-  { path: '/menu', component: MenuPage }
+  { path: '/menu', component: MenuPage },
+  { path: '/login', component: LoginPage }
 ]
 
 const router = createRouter({
   history: createWebHistory(),
   routes
+})
+
+/* global localStorage */
+let authNeeded: boolean | null = null
+router.beforeEach(async (to) => {
+  if (authNeeded === null) {
+    authNeeded = (await checkAuthRequired()).required
+  }
+  if (!authNeeded) return true
+  if (to.path === '/login') return true
+  if (localStorage.getItem('loggedIn') === '1') return true
+  return '/login'
 })
 
 export default router


### PR DESCRIPTION
## Summary
- implement cookie-based authentication backend with login/logout routes
- add auth middleware and routes to express app
- add frontend login page and router guard
- update API helpers and tests
- add comprehensive unit tests for auth flows

## Testing
- `npm --prefix backend run lint`
- `npm --prefix frontend run lint`
- `npm --prefix backend test`
- `npm --prefix frontend test`
- `npm --prefix backend run build`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_6843dca99f2483239f08871cd0f9cf8a