### PR TITLE
Externalize translations to JSON

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "vue": "^3.5.13",
+        "vue-i18n": "^9.9.0",
         "vue-router": "^4.5.1"
       },
       "devDependencies": {
@@ -1279,6 +1280,50 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "9.14.4",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.4.tgz",
+      "integrity": "sha512-vtZCt7NqWhKEtHa3SD/322DlgP5uR9MqWxnE0y8Q0tjDs9H5Lxhss+b5wv8rmuXRoHKLESNgw9d+EN9ybBbj9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "9.14.4",
+        "@intlify/shared": "9.14.4"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "9.14.4",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.4.tgz",
+      "integrity": "sha512-vcyCLiVRN628U38c3PbahrhbbXrckrM9zpy0KZVlDk2Z0OnGwv8uQNNXP3twwGtfLsCf4gu3ci6FMIZnPaqZsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "9.14.4",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "9.14.4",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.4.tgz",
+      "integrity": "sha512-P9zv6i1WvMc9qDBWvIgKkymjY2ptIiQ065PjDv7z7fDqH3J/HBRBN5IoiR46r/ujRcU7hCuSIZWvCAFCyuOYZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -5916,6 +5961,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "9.14.4",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.4.tgz",
+      "integrity": "sha512-B934C8yUyWLT0EMud3DySrwSUJI7ZNiWYsEEz2gknTthqKiG4dzWE/WSa8AzCuSQzwBEv4HtG1jZDhgzPfWSKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "9.14.4",
+        "@intlify/shared": "9.14.4",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "vue": "^3.5.13",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "vue-i18n": "^9.9.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,20 +7,20 @@ import { RouterLink, RouterView } from 'vue-router'
     <header class="bg-gradient-to-r from-blue-500 to-indigo-600 text-white py-4">
       <div class="container mx-auto px-4 flex items-center justify-between">
         <h1 class="text-xl font-semibold">
-          Repas Planner
+          {{ $t('app.title') }}
         </h1>
         <nav class="space-x-4 font-medium">
           <RouterLink
             to="/recipes"
             class="hover:underline"
           >
-            Recettes
+            {{ $t('app.recipes') }}
           </RouterLink>
           <RouterLink
             to="/menu"
             class="hover:underline"
           >
-            Menu
+            {{ $t('app.menu') }}
           </RouterLink>
         </nav>
       </div>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,0 +1,14 @@
+import { createI18n } from 'vue-i18n'
+import en from './locales/en.json'
+import fr from './locales/fr.json'
+/* global navigator, document */
+
+export const messages = { en, fr }
+
+export function setupI18n() {
+  const user = navigator.language.split('-')[0]
+  const locale = user in messages ? user : 'en'
+  const i18n = createI18n({ legacy: false, locale, fallbackLocale: 'en', messages })
+  document.documentElement.lang = locale
+  return i18n
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,0 +1,67 @@
+{
+  "common": { "to": "to" },
+  "app": {
+    "title": "Repas Planner",
+    "recipes": "Recipes",
+    "menu": "Menu"
+  },
+  "addRecipe": {
+    "editTitle": "Edit recipe",
+    "addTitle": "Add a recipe",
+    "name": "Name",
+    "instructions": "Instructions",
+    "imageUrl": "Image URL",
+    "ingredients": "Ingredients",
+    "mainIngredient": "Main recipe ingredient",
+    "secondaryIngredient": "Secondary ingredient",
+    "removeIngredient": "Remove ingredient",
+    "addIngredient": "Add ingredient",
+    "save": "Save"
+  },
+  "login": {
+    "title": "Login",
+    "username": "Username",
+    "password": "Password",
+    "submit": "Sign in"
+  },
+  "menuPage": {
+    "title": "Menu for {range}",
+    "previousWeek": "Previous week",
+    "nextWeek": "Next week",
+    "generateMenu": "Generate menu",
+    "shoppingListWeek": "Shopping list for the week",
+    "day": "Day",
+    "lunch": "Lunch",
+    "dinner": "Dinner",
+    "generate": "Generate",
+    "cancel": "Cancel",
+    "shoppingList": "Shopping list",
+    "close": "Close"
+  },
+  "recipeDetail": {
+    "back": "Back",
+    "ingredients": "Ingredients",
+    "description": "Description",
+    "edit": "Edit",
+    "delete": "Delete",
+    "deleteConfirm": "Delete this recipe?"
+  },
+  "recipesPage": {
+    "title": "Recipes",
+    "addRecipe": "Add recipe",
+    "importExport": "Import/Export",
+    "fileToImport": "File to import",
+    "import": "Import",
+    "export": "Export",
+    "imageAlt": "Recipe image"
+  },
+  "days": {
+    "lundi": "Monday",
+    "mardi": "Tuesday",
+    "mercredi": "Wednesday",
+    "jeudi": "Thursday",
+    "vendredi": "Friday",
+    "samedi": "Saturday",
+    "dimanche": "Sunday"
+  }
+}

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -1,0 +1,67 @@
+{
+  "common": { "to": "au" },
+  "app": {
+    "title": "Repas Planner",
+    "recipes": "Recettes",
+    "menu": "Menu"
+  },
+  "addRecipe": {
+    "editTitle": "Modifier la recette",
+    "addTitle": "Ajouter une recette",
+    "name": "Nom",
+    "instructions": "Instructions",
+    "imageUrl": "URL de l'image",
+    "ingredients": "Ingrédients",
+    "mainIngredient": "Ingrédient principal de la recette",
+    "secondaryIngredient": "Ingrédient secondaire",
+    "removeIngredient": "Supprimer l'ingrédient",
+    "addIngredient": "Ajouter un ingrédient",
+    "save": "Enregistrer"
+  },
+  "login": {
+    "title": "Connexion",
+    "username": "Nom d'utilisateur",
+    "password": "Mot de passe",
+    "submit": "Se connecter"
+  },
+  "menuPage": {
+    "title": "Menu du {range}",
+    "previousWeek": "Semaine précédente",
+    "nextWeek": "Semaine suivante",
+    "generateMenu": "Générer le menu",
+    "shoppingListWeek": "Liste de course de la semaine",
+    "day": "Jour",
+    "lunch": "Déjeuner",
+    "dinner": "Diner",
+    "generate": "Générer",
+    "cancel": "Annuler",
+    "shoppingList": "Liste de course",
+    "close": "Fermer"
+  },
+  "recipeDetail": {
+    "back": "Retour",
+    "ingredients": "Ingrédients",
+    "description": "Description",
+    "edit": "Éditer",
+    "delete": "Supprimer",
+    "deleteConfirm": "Supprimer cette recette ?"
+  },
+  "recipesPage": {
+    "title": "Recettes",
+    "addRecipe": "Ajouter une recette",
+    "importExport": "Importer/Exporter",
+    "fileToImport": "fichier à importer",
+    "import": "Importer",
+    "export": "Exporter",
+    "imageAlt": "Image de la recette"
+  },
+  "days": {
+    "lundi": "lundi",
+    "mardi": "mardi",
+    "mercredi": "mercredi",
+    "jeudi": "jeudi",
+    "vendredi": "vendredi",
+    "samedi": "samedi",
+    "dimanche": "dimanche"
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,5 +2,7 @@ import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'
 import router from './router'
+import { setupI18n } from './i18n'
 
-createApp(App).use(router).mount('#app')
+const i18n = setupI18n()
+createApp(App).use(router).use(i18n).mount('#app')

--- a/frontend/src/pages/AddRecipePage.test.ts
+++ b/frontend/src/pages/AddRecipePage.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, type Mock } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createRouter, createWebHistory } from 'vue-router'
+import { createI18n } from 'vue-i18n'
+import { messages } from '../i18n'
 import AddRecipePage from './AddRecipePage.vue'
 import { routes } from '../router'
 import * as api from '../api'
@@ -11,9 +13,10 @@ async function setup(path: string) {
   const router = createRouter({ history: createWebHistory(), routes })
   router.push(path)
   await router.isReady()
+  const i18n = createI18n({ legacy: false, locale: 'en', messages })
   return mount(AddRecipePage, {
     global: {
-      plugins: [router],
+      plugins: [router, i18n],
       stubs: { IngredientInput: { template: '<div></div>' } }
     }
   })

--- a/frontend/src/pages/AddRecipePage.vue
+++ b/frontend/src/pages/AddRecipePage.vue
@@ -88,14 +88,14 @@ onMounted(async () => {
 <template>
   <div class="max-w-md mx-auto">
     <h1 class="text-2xl font-bold mb-4">
-      {{ isEdit ? 'Modifier la recette' : 'Ajouter une recette' }}
+      {{ isEdit ? $t('addRecipe.editTitle') : $t('addRecipe.addTitle') }}
     </h1>
     <form
       class="space-y-4"
       @submit.prevent="submit"
     >
       <div>
-        <label class="block mb-1">Nom</label>
+        <label class="block mb-1">{{ $t('addRecipe.name') }}</label>
         <input
           v-model="nom"
           class="border rounded w-full p-2"
@@ -103,21 +103,21 @@ onMounted(async () => {
         >
       </div>
       <div>
-        <label class="block mb-1">Instructions</label>
+        <label class="block mb-1">{{ $t('addRecipe.instructions') }}</label>
         <textarea
           v-model="instructions"
           class="border rounded w-full p-2"
         />
       </div>
       <div>
-        <label class="block mb-1">URL de l'image</label>
+        <label class="block mb-1">{{ $t('addRecipe.imageUrl') }}</label>
         <input
           v-model="imageUrl"
           class="border rounded w-full p-2"
         >
       </div>
       <div>
-        <label class="block mb-1">Ingrédients</label>
+        <label class="block mb-1">{{ $t('addRecipe.ingredients') }}</label>
         <div
           v-for="(_, idx) in ingredients"
           :key="idx"
@@ -128,7 +128,7 @@ onMounted(async () => {
             v-if="idx === 0"
             class="text-sm text-gray-500"
           >
-            Ingrédient principal de la recette
+            {{ $t('addRecipe.mainIngredient') }}
           </p>
           <div
             v-if="idx > 0"
@@ -140,14 +140,14 @@ onMounted(async () => {
                 :checked="secondaryIdx === idx"
                 @change="toggleSecondary(idx)"
               >
-              <span>Ingrédient secondaire</span>
+              <span>{{ $t('addRecipe.secondaryIngredient') }}</span>
             </label>
             <button
               type="button"
               class="text-red-600 text-sm"
               @click="removeIngredient(idx)"
             >
-              Supprimer l'ingrédient
+              {{ $t('addRecipe.removeIngredient') }}
             </button>
           </div>
         </div>
@@ -156,14 +156,14 @@ onMounted(async () => {
           class="px-2 py-1 bg-gray-200 rounded"
           @click="addIngredient"
         >
-          Ajouter un ingrédient
+          {{ $t('addRecipe.addIngredient') }}
         </button>
       </div>
       <button
         type="submit"
         class="px-3 py-1 bg-blue-600 text-white rounded"
       >
-        Enregistrer
+        {{ $t('addRecipe.save') }}
       </button>
     </form>
   </div>

--- a/frontend/src/pages/LoginPage.test.ts
+++ b/frontend/src/pages/LoginPage.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createRouter, createWebHistory } from 'vue-router'
+import { createI18n } from 'vue-i18n'
+import { messages } from '../i18n'
 import LoginPage from './LoginPage.vue'
 import { routes } from '../router'
 import * as api from '../api'
@@ -11,7 +13,8 @@ async function setup() {
   const router = createRouter({ history: createWebHistory(), routes })
   router.push('/login')
   await router.isReady()
-  return mount(LoginPage, { global: { plugins: [router] } })
+  const i18n = createI18n({ legacy: false, locale: 'en', messages })
+  return mount(LoginPage, { global: { plugins: [router, i18n] } })
 }
 
 describe('LoginPage', () => {

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -25,10 +25,10 @@ async function submit() {
     @submit.prevent="submit"
   >
     <h1 class="text-2xl font-bold mb-4">
-      Connexion
+      {{ $t('login.title') }}
     </h1>
     <div class="mb-2">
-      <label class="block mb-1">Nom d'utilisateur</label>
+      <label class="block mb-1">{{ $t('login.username') }}</label>
       <input
         v-model="username"
         class="border rounded w-full p-2"
@@ -36,7 +36,7 @@ async function submit() {
       >
     </div>
     <div class="mb-4">
-      <label class="block mb-1">Mot de passe</label>
+      <label class="block mb-1">{{ $t('login.password') }}</label>
       <input
         v-model="password"
         type="password"
@@ -45,7 +45,7 @@ async function submit() {
       >
     </div>
     <button class="px-3 py-1 bg-blue-600 text-white rounded">
-      Se connecter
+      {{ $t('login.submit') }}
     </button>
   </form>
 </template>

--- a/frontend/src/pages/MenuPage.vue
+++ b/frontend/src/pages/MenuPage.vue
@@ -2,12 +2,14 @@
 /* eslint-disable vue/singleline-html-element-content-newline, vue/max-attributes-per-line, vue/html-self-closing, vue/attributes-order */
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { fetchMenu, generateMenu, fetchShoppingList } from '../api'
 import type { MenuRecipe, ShoppingIngredient } from '../api'
 import { weekRange, weekString } from '../week'
 
 const route = useRoute()
 const router = useRouter()
+const { t } = useI18n()
 const week = ref<string>((route.query.week as string) || weekString(new Date()))
 const menu = ref<MenuRecipe[]>([])
 const showModal = ref(false)
@@ -18,7 +20,7 @@ const shopping = ref<ShoppingIngredient[]>([])
 const range = computed(() => {
   const { start, end } = weekRange(week.value)
   const fmt = (d: Date) => d.toISOString().slice(0, 10)
-  return `${fmt(start)} au ${fmt(end)}`
+  return `${fmt(start)} ${t('common.to')} ${fmt(end)}`
 })
 
 async function load() {
@@ -71,24 +73,24 @@ onMounted(load)
 </script>
 <template>
   <div>
-    <h1 class="text-2xl font-bold mb-4">Menu du {{ range }}</h1>
+    <h1 class="text-2xl font-bold mb-4">{{ $t('menuPage.title', { range }) }}</h1>
     <div class="mb-2 flex space-x-2">
-      <button class="px-2 py-1 bg-gray-200" @click="change(-1)">Semaine précédente</button>
-      <button class="px-2 py-1 bg-gray-200" @click="change(1)">Semaine suivante</button>
-      <button class="px-2 py-1 bg-blue-600 text-white" @click="openModal">Générer le menu</button>
-      <button class="ml-auto px-2 py-1 bg-green-600 text-white" @click="openShopping">Liste de course de la semaine</button>
+      <button class="px-2 py-1 bg-gray-200" @click="change(-1)">{{ $t('menuPage.previousWeek') }}</button>
+      <button class="px-2 py-1 bg-gray-200" @click="change(1)">{{ $t('menuPage.nextWeek') }}</button>
+      <button class="px-2 py-1 bg-blue-600 text-white" @click="openModal">{{ $t('menuPage.generateMenu') }}</button>
+      <button class="ml-auto px-2 py-1 bg-green-600 text-white" @click="openShopping">{{ $t('menuPage.shoppingListWeek') }}</button>
     </div>
     <table class="w-full text-left">
       <thead>
         <tr>
-          <th>Jour</th>
-          <th>Déjeuner</th>
-          <th>Diner</th>
+          <th>{{ $t('menuPage.day') }}</th>
+          <th>{{ $t('menuPage.lunch') }}</th>
+          <th>{{ $t('menuPage.dinner') }}</th>
         </tr>
       </thead>
       <tbody>
         <tr v-for="day in ['lundi','mardi','mercredi','jeudi','vendredi','samedi','dimanche']" :key="day">
-          <td class="capitalize">{{ day }}</td>
+          <td class="capitalize">{{ $t(`days.${day}`) }}</td>
           <td>
             <RouterLink
               v-if="menu.find(m => m.jour === day && m.moment === 'dejeuner')?.recipe_id"
@@ -119,8 +121,8 @@ onMounted(load)
           <thead>
             <tr>
               <th></th>
-              <th>Déjeuner</th>
-              <th>Diner</th>
+              <th>{{ $t('menuPage.lunch') }}</th>
+              <th>{{ $t('menuPage.dinner') }}</th>
             </tr>
           </thead>
           <tbody>
@@ -132,21 +134,21 @@ onMounted(load)
           </tbody>
         </table>
         <div class="mt-2 space-x-2">
-          <button class="px-2 py-1 bg-blue-600 text-white" @click="gen">Générer</button>
-          <button class="px-2 py-1 bg-gray-200" @click="showModal=false">Annuler</button>
+          <button class="px-2 py-1 bg-blue-600 text-white" @click="gen">{{ $t('menuPage.generate') }}</button>
+          <button class="px-2 py-1 bg-gray-200" @click="showModal=false">{{ $t('menuPage.cancel') }}</button>
         </div>
       </div>
     </div>
     <div v-if="showShopping" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
       <div class="bg-white p-4">
-        <h2 class="text-lg font-bold mb-2">Liste de course</h2>
+        <h2 class="text-lg font-bold mb-2">{{ $t('menuPage.shoppingList') }}</h2>
         <ul class="list-disc list-inside">
           <li v-for="ing in shopping" :key="ing.id">
             {{ ing.nom }} : {{ ing.quantite }} {{ ing.unite }}
           </li>
         </ul>
         <div class="mt-2 text-right">
-          <button class="px-2 py-1 bg-gray-200" @click="showShopping=false">Fermer</button>
+          <button class="px-2 py-1 bg-gray-200" @click="showShopping=false">{{ $t('menuPage.close') }}</button>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/RecipeDetailPage.test.ts
+++ b/frontend/src/pages/RecipeDetailPage.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, type Mock, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createRouter, createWebHistory } from 'vue-router'
+import { createI18n } from 'vue-i18n'
+import { messages } from '../i18n'
 import RecipeDetailPage from './RecipeDetailPage.vue'
 import { routes } from '../router'
 import * as api from '../api'
@@ -20,7 +22,8 @@ async function setup() {
   const router = createRouter({ history: createWebHistory(), routes })
   router.push('/recipes/r1')
   await router.isReady()
-  const wrapper = mount(RecipeDetailPage, { global: { plugins: [router] } })
+  const i18n = createI18n({ legacy: false, locale: 'en', messages })
+  const wrapper = mount(RecipeDetailPage, { global: { plugins: [router, i18n] } })
   return { wrapper, router }
 }
 

--- a/frontend/src/pages/RecipeDetailPage.vue
+++ b/frontend/src/pages/RecipeDetailPage.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { fetchRecipe, fetchRecipeIngredients, deleteRecipe } from '../api'
 import type { Recipe, RecipeIngredient } from '../api'
 
 const route = useRoute()
 const router = useRouter()
+const { t } = useI18n()
 const recipe = ref<Recipe | null>(null)
 const ingredients = ref<RecipeIngredient[]>([])
 
@@ -21,7 +23,7 @@ onMounted(async () => {
 
 async function remove() {
   if (!recipe.value) return
-  if (!globalThis.confirm('Supprimer cette recette ?')) return
+  if (!globalThis.confirm(t('recipeDetail.deleteConfirm'))) return
   try {
     await deleteRecipe(recipe.value.id)
     router.push('/recipes')
@@ -40,7 +42,7 @@ async function remove() {
       class="text-blue-600"
       @click="router.back()"
     >
-      &larr; Retour
+      &larr; {{ $t('recipeDetail.back') }}
     </button>
     <h1 class="text-3xl font-bold my-4">
       {{ recipe.nom }}
@@ -51,7 +53,7 @@ async function remove() {
       class="mb-4 w-full object-cover rounded"
     >
     <h2 class="text-xl font-semibold mb-2">
-      Ingrédients
+      {{ $t('recipeDetail.ingredients') }}
     </h2>
     <ul class="list-disc list-inside mb-4">
       <li
@@ -62,7 +64,7 @@ async function remove() {
       </li>
     </ul>
     <h2 class="text-xl font-semibold mb-2">
-      Description
+      {{ $t('recipeDetail.description') }}
     </h2>
     <p class="whitespace-pre-line">
       {{ recipe.instructions }}
@@ -72,14 +74,14 @@ async function remove() {
         :to="`/recipes/${recipe.id}/edit`"
         class="px-3 py-1 bg-blue-600 text-white rounded"
       >
-        Éditer
+        {{ $t('recipeDetail.edit') }}
       </RouterLink>
       <button
         type="button"
         class="px-3 py-1 bg-red-600 text-white rounded"
         @click="remove"
       >
-        Supprimer
+        {{ $t('recipeDetail.delete') }}
       </button>
     </div>
   </div>

--- a/frontend/src/pages/RecipesPage.test.ts
+++ b/frontend/src/pages/RecipesPage.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, type Mock } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createRouter, createWebHistory } from 'vue-router'
+import { createI18n } from 'vue-i18n'
+import { messages } from '../i18n'
 import RecipesPage from './RecipesPage.vue'
 import { routes } from '../router'
 import * as api from '../api'
@@ -11,7 +13,8 @@ async function setup() {
   const router = createRouter({ history: createWebHistory(), routes })
   router.push('/recipes')
   await router.isReady()
-  return mount(RecipesPage, { global: { plugins: [router] } })
+  const i18n = createI18n({ legacy: false, locale: 'en', messages })
+  return mount(RecipesPage, { global: { plugins: [router, i18n] } })
 }
 
 describe('RecipesPage', () => {

--- a/frontend/src/pages/RecipesPage.vue
+++ b/frontend/src/pages/RecipesPage.vue
@@ -50,21 +50,21 @@ onMounted(async () => {
   <div>
     <div class="flex items-center justify-between mb-4">
       <h1 class="text-2xl font-bold">
-        Recettes
+        {{ $t('recipesPage.title') }}
       </h1>
       <div class="flex gap-2">
         <RouterLink
           to="/recipes/add"
           class="px-3 py-1 bg-blue-600 text-white rounded"
         >
-          Ajouter une recette
+          {{ $t('recipesPage.addRecipe') }}
         </RouterLink>
         <button
           data-test="import-btn"
           class="px-3 py-1 bg-green-600 text-white rounded"
           @click="showImport = true"
         >
-          Importer/Exporter
+          {{ $t('recipesPage.importExport') }}
         </button>
       </div>
     </div>
@@ -77,7 +77,7 @@ onMounted(async () => {
       >
         <img
           :src="recipe.image_url || placeholderImg"
-          alt="Image de la recette"
+          :alt="$t('recipesPage.imageAlt')"
           class="w-full h-32 object-cover rounded mb-2"
         >
         <h2 class="font-medium text-lg mb-1">
@@ -94,7 +94,7 @@ onMounted(async () => {
     >
       <div class="bg-white p-4 rounded space-y-4">
         <div>
-          <label class="block mb-2">fichier à importer</label>
+          <label class="block mb-2">{{ $t('recipesPage.fileToImport') }}</label>
           <input
             type="file"
             @change="onFile"
@@ -103,7 +103,7 @@ onMounted(async () => {
             class="ml-2 px-3 py-1 bg-blue-600 text-white rounded"
             @click="doImport"
           >
-            Importer
+            {{ $t('recipesPage.import') }}
           </button>
         </div>
         <div class="text-right">
@@ -111,7 +111,7 @@ onMounted(async () => {
             class="px-3 py-1 bg-green-600 text-white rounded"
             @click="doExport"
           >
-            Exporter
+            {{ $t('recipesPage.export') }}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- move locale strings into new JSON files
- import locale JSON in the i18n setup
- keep locale auto-detection with English fallback

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843e23a02cc8323802a2714ed1a25d3