### PR TITLE
Handle 401 responses in frontend API

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fetchShoppingList, exportRecipes, importRecipes, getApiBaseUrl, checkAuthRequired, login } from './api'
+import { fetchShoppingList, exportRecipes, importRecipes, getApiBaseUrl, checkAuthRequired, login, apiFetch } from './api'
+
+/* global localStorage */
 
 const data = [{ id: 'i1', nom: 'Beurre', quantite: '700', unite: 'g' }]
 
@@ -58,5 +60,16 @@ describe('auth helpers', () => {
     const call = (globalThis.fetch as unknown as vi.Mock).mock.calls[0]
     expect(call[0]).toBe('http://localhost:3000/api/login')
     expect(call[1].credentials).toBe('include')
+  })
+
+  it('apiFetch redirects on 401', async () => {
+    const response = { status: 401, ok: false }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response))
+    vi.stubGlobal('location', { assign: vi.fn() })
+    localStorage.setItem('loggedIn', '1')
+    const res = await apiFetch('url')
+    expect(res).toBe(response)
+    expect(localStorage.getItem('loggedIn')).toBeNull()
+    expect(globalThis.location.assign).toHaveBeenCalledWith('/login')
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-/* global RequestInfo, RequestInit */
+/* global RequestInfo, RequestInit, localStorage, location */
 export function getApiBaseUrl(env: { PROD: boolean } = import.meta.env) {
   return env.PROD ? `${globalThis.location.origin}/api` : 'http://localhost:3000/api'
 }
@@ -6,7 +6,12 @@ export function getApiBaseUrl(env: { PROD: boolean } = import.meta.env) {
 export const API_BASE_URL = getApiBaseUrl()
 
 export async function apiFetch(input: RequestInfo, init: RequestInit = {}) {
-  return globalThis.fetch(input, { credentials: 'include', ...init })
+  const res = await globalThis.fetch(input, { credentials: 'include', ...init })
+  if (res.status === 401) {
+    localStorage.removeItem('loggedIn')
+    location.assign('/login')
+  }
+  return res
 }
 
 export async function checkAuthRequired() {
@@ -24,7 +29,6 @@ export async function login(username: string, password: string) {
   return res.json()
 }
 
-/* global localStorage */
 export async function logout() {
   await apiFetch(`${API_BASE_URL}/logout`, { method: 'POST' })
   localStorage.removeItem('loggedIn')


### PR DESCRIPTION
## Summary
- clear auth state and redirect to the login page when a request returns HTTP 401
- test the new behaviour in `apiFetch`

## Testing
- `npm run -s lint`
- `npm run -s test`
- `npm run -s build`

------
https://chatgpt.com/codex/tasks/task_e_6843e8229924832386a9f067b2afbcf3