### PR TITLE
Load ingredient list once

### DIFF
--- a/backend/src/routes/ingredients.ts
+++ b/backend/src/routes/ingredients.ts
@@ -24,6 +24,21 @@ router.get('/', async (req: Request, res: Response, next: NextFunction): Promise
   }
 });
 
+// GET /ingredients/all - list all ingredients
+router.get('/all', async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { rows } = await pool.query(
+      `SELECT i.id, i.nom, u.nom AS unite
+       FROM ingredients i
+       LEFT JOIN unites u ON u.id = i.unite_id
+       ORDER BY i.nom`
+    );
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
 // POST /ingredients - create a new ingredient
 router.post('/', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const { nom, unite } = req.body;

--- a/backend/src/routes/unites.ts
+++ b/backend/src/routes/unites.ts
@@ -21,5 +21,19 @@ router.get('/', async (req: Request, res: Response, next: NextFunction): Promise
   }
 });
 
+// GET /unites/all - list all units
+router.get('/all', async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { rows } = await pool.query(
+      `SELECT id, nom
+       FROM unites
+       ORDER BY nom`
+    );
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
 export default router;
 

--- a/backend/tests/app.test.ts
+++ b/backend/tests/app.test.ts
@@ -66,6 +66,19 @@ describe('GET /unites', () => {
   });
 });
 
+describe('GET /ingredients/all and /unites/all', () => {
+  it('lists all items', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 'i1', nom: 'Tomate', unite: 'kg' }] });
+    const resIng = await request(app).get('/api/ingredients/all');
+    expect(resIng.status).toBe(200);
+    expect(resIng.body[0].nom).toBe('Tomate');
+    mockedQuery.mockResolvedValueOnce({ rows: [{ id: 'u1', nom: 'kg' }] });
+    const resU = await request(app).get('/api/unites/all');
+    expect(resU.status).toBe(200);
+    expect(resU.body[0].nom).toBe('kg');
+  });
+});
+
 describe('GET /menus/:week/shopping-list', () => {
   it('returns aggregated ingredients', async () => {
     mockedQuery.mockResolvedValueOnce({ rows: [{ id: 'i1', nom: 'Beurre', quantite: '700', unite: 'g' }] });

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fetchShoppingList, exportRecipes, importRecipes, getApiBaseUrl, checkAuthRequired, login, apiFetch } from './api'
+import { fetchShoppingList, exportRecipes, importRecipes, getApiBaseUrl, checkAuthRequired, login, apiFetch, fetchAllIngredients, fetchAllUnites } from './api'
 
 /* global localStorage */
 
@@ -20,6 +20,23 @@ describe('fetchShoppingList', () => {
   it('throws on failure', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
     await expect(fetchShoppingList('w')).rejects.toThrow('Failed to fetch shopping list')
+  })
+})
+
+describe('fetchAllIngredients/unites', () => {
+  it('returns lists', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([{ id: 'i1', nom: 'Tomate' }]) }))
+    const resIng = await fetchAllIngredients()
+    expect(globalThis.fetch).toHaveBeenCalledWith('http://localhost:3000/api/ingredients/all', { credentials: 'include' })
+    expect(resIng[0].nom).toBe('Tomate')
+    ;(globalThis.fetch as unknown as vi.Mock).mockResolvedValue({ ok: true, json: () => Promise.resolve([{ id: 'u1', nom: 'kg' }]) })
+    const resU = await fetchAllUnites()
+    expect(resU[0].nom).toBe('kg')
+  })
+
+  it('throws on failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
+    await expect(fetchAllIngredients()).rejects.toThrow('Failed to fetch ingredients')
   })
 })
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -146,10 +146,26 @@ export async function searchIngredients(search: string): Promise<Ingredient[]> {
   return res.json()
 }
 
+export async function fetchAllIngredients(): Promise<Ingredient[]> {
+  const res = await apiFetch(`${API_BASE_URL}/ingredients/all`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch ingredients')
+  }
+  return res.json()
+}
+
 export async function searchUnites(search: string): Promise<Unite[]> {
   const params = new globalThis.URLSearchParams()
   params.set('search', search)
   const res = await apiFetch(`${API_BASE_URL}/unites?${params.toString()}`)
+  if (!res.ok) {
+    throw new Error('Failed to fetch unites')
+  }
+  return res.json()
+}
+
+export async function fetchAllUnites(): Promise<Unite[]> {
+  const res = await apiFetch(`${API_BASE_URL}/unites/all`)
   if (!res.ok) {
     throw new Error('Failed to fetch unites')
   }

--- a/frontend/src/components/IngredientInput.test.ts
+++ b/frontend/src/components/IngredientInput.test.ts
@@ -7,13 +7,13 @@ vi.mock('../api')
 
 describe('IngredientInput', () => {
   it('shows suggestions and allows picking', async () => {
-    ;(api.searchIngredients as unknown as Mock).mockResolvedValue([{ id: 'i1', nom: 'Tomate', unite: 'kg' }])
-    ;(api.searchUnites as unknown as Mock).mockResolvedValue([{ id: 'u1', nom: 'kg' }])
+    ;(api.fetchAllIngredients as unknown as Mock).mockResolvedValue([{ id: 'i1', nom: 'Tomate', unite: 'kg' }])
+    ;(api.fetchAllUnites as unknown as Mock).mockResolvedValue([{ id: 'u1', nom: 'kg' }])
 
     const wrapper = mount(IngredientInput, {
       props: { modelValue: { nom: '', quantite: '', unite: '' } }
     })
-
+    await flushPromises()
     await wrapper.get('input[placeholder="Ingrédient"]').setValue('tom')
     await flushPromises()
     const itemsIng = wrapper.findAll('ul li').map(li => li.text())
@@ -31,13 +31,14 @@ describe('IngredientInput', () => {
   })
 
   it('handles unit search errors', async () => {
-    ;(api.searchIngredients as unknown as Mock).mockResolvedValue([])
-    ;(api.searchUnites as unknown as Mock).mockRejectedValue(new Error('fail'))
+    ;(api.fetchAllIngredients as unknown as Mock).mockResolvedValue([])
+    ;(api.fetchAllUnites as unknown as Mock).mockRejectedValue(new Error('fail'))
 
     const wrapper = mount(IngredientInput, {
       props: { modelValue: { nom: '', quantite: '', unite: '' } }
     })
 
+    await flushPromises()
     await wrapper.get('input[placeholder="Unité"]').setValue('k')
     await flushPromises()
     expect(wrapper.findAll('ul li')).toHaveLength(0)


### PR DESCRIPTION
## Summary
- load ingredient & unit lists once and filter locally
- add endpoints to list all ingredients & units
- test new API helpers and routes
- update ingredient input behavior and tests

## Testing
- `npm run lint` in backend
- `npm test` in backend
- `npm run build` in backend
- `npm run lint` in frontend
- `npm test` in frontend
- `npm run build` in frontend

------
https://chatgpt.com/codex/tasks/task_e_6843fb106ad08323b6af2c8a39de7d71