### PR TITLE
Fix ingredient input infinite loop

### DIFF
--- a/frontend/src/components/IngredientInput.vue
+++ b/frontend/src/components/IngredientInput.vue
@@ -19,6 +19,10 @@ const emit = defineEmits<{
 }>()
 
 const data = ref({ ...props.modelValue })
+
+function equal(a: IngredientData, b: IngredientData) {
+  return a.id === b.id && a.nom === b.nom && a.quantite === b.quantite && a.unite === b.unite
+}
 const suggestions = ref<Ingredient[]>([])
 const unitSuggestions = ref<Unite[]>([])
 const justPicked = ref(false)
@@ -38,11 +42,24 @@ onMounted(async () => {
   }
 })
 
-watch(() => props.modelValue, v => {
-  data.value = { ...v }
-})
-
-watch(data, v => emit('update:modelValue', v), { deep: true })
+watch(
+  () => props.modelValue,
+  v => {
+    if (!equal(v, data.value)) {
+      data.value = { ...v }
+    }
+  },
+  { deep: true }
+)
+watch(
+  data,
+  v => {
+    if (!equal(v, props.modelValue)) {
+      emit('update:modelValue', v)
+    }
+  },
+  { deep: true }
+)
 
 watch(
   () => data.value.nom,

--- a/frontend/src/components/IngredientInputLoop.test.ts
+++ b/frontend/src/components/IngredientInputLoop.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, type Mock } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import IngredientInput from './IngredientInput.vue'
+import * as api from '../api'
+
+vi.mock('../api')
+
+describe('IngredientInput loop', () => {
+  it('emits once with v-model', async () => {
+    ;(api.fetchAllIngredients as unknown as Mock).mockResolvedValue([])
+    ;(api.fetchAllUnites as unknown as Mock).mockResolvedValue([])
+    const wrapper = mount(IngredientInput, {
+      props: {
+        modelValue: { nom: '', quantite: '', unite: '' },
+        'onUpdate:modelValue': (v: unknown) => wrapper.setProps({ modelValue: v })
+      }
+    })
+    await flushPromises()
+    await wrapper.get('input[placeholder="Ingrédient"]').setValue('tom')
+    await flushPromises()
+    expect(wrapper.emitted('update:modelValue')!.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- avoid recursion when IngredientInput uses v-model
- test v-model to make sure only one update event occurs

## Testing
- `npm run lint` in backend
- `npm run test` in backend
- `npm run build` in backend
- `npm run lint` in frontend
- `npm run test` in frontend
- `npm run build` in frontend

------
https://chatgpt.com/codex/tasks/task_e_6843feab862083239af86f3b276b2c7c